### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: python
 python:
     - 2.6
     - 2.7
-    - 3.3
     - 3.4
+    - 3.5
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
-    - export PATH=$HOME/miniconda/bin:$PATH
+    - export PATH=$HOME/miniconda2/bin:$PATH
     - conda update --yes conda
 
     # Make sure that interactive matplotlib backends work

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
+    - export PATH=$HOME/miniconda/bin:$PATH
     - conda update --yes conda
 
     # Make sure that interactive matplotlib backends work

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ModestImage
 
+[![Build Status](https://travis-ci.org/ChrisBeaumont/mpl-modest-image.svg?branch=master)](https://travis-ci.org/ChrisBeaumont/mpl-modest-image)
 
 *Friendlier matplotlib interaction with large images*
 


### PR DESCRIPTION
Three fixes:
- New miniconda installs in `$HOME/miniconda2/` folder instead of `$HOME/miniconda/`
- Update to test against Python 3.5
- Add Travis badge in README.md
