### PR TITLE
Extent

### DIFF
--- a/modest_image/modest_image.py
+++ b/modest_image/modest_image.py
@@ -77,7 +77,10 @@ class ModestImage(mi.AxesImage):
         x0 = y0 = 0.0
         y1, x1 = self._full_res.shape
         arrayLim = extent_to_bbox(x0, x1, y0, y1, self.origin)
-        dataLim = self.axes.dataLim
+        
+        x0, x1, y0, y1 = self.get_extent()
+        dataLim = extent_to_bbox(x0, x1, y0, y1, self.origin)
+
         self._scale_transform = mtransforms.BboxTransform(dataLim, arrayLim)
         return self._scale_transform
 
@@ -98,7 +101,7 @@ class ModestImage(mi.AxesImage):
         self._A = self._full_res[y0:y1:sy, x0:x1:sx]
         self._A = cbook.safe_masked_invalid(self._A)
         
-        extentLim = extent_to_bbox(x0 - .5, x1 - .5, y0 - .5, y1 - .5, self.origin)
+        extentLim = extent_to_bbox(x0, x1, y0, y1, self.origin)
         extentLim = transform.inverted().transform_bbox(extentLim)
         extent = bbox_to_extent(extentLim, self.origin)
         self.set_extent(extent)

--- a/modest_image/tests/test_modest_image.py
+++ b/modest_image/tests/test_modest_image.py
@@ -224,3 +224,22 @@ def test_get_array():
     modest.axes.figure.canvas.draw()
     np.testing.assert_array_equal(modest.get_array(),
                                   ax.get_array())
+
+def test_extent():
+    """extent"""
+    data = default_data()
+    modest = init(ModestImage, data)
+    axim = init(mi.AxesImage, data)
+    
+    modest.axes.set_autoscale_on(True) # Reactivate autoscale
+    axim.axes.set_autoscale_on(True)
+    
+    extent = [0.0, 5.0, 0.0, 5.0]
+    modest.set_extent(extent)
+    axim.set_extent(extent)
+    check('extent', modest.axes, axim.axes, thresh=0.3)
+    
+    extent = [0.0, 50.0, 0.0, 5.0]
+    modest.set_extent(extent)
+    axim.set_extent(extent)
+    check('extent', modest.axes, axim.axes, thresh=0.8)


### PR DESCRIPTION
Allow `set_extent` to work with ModestImage. The implementation uses matplotlib's transformation to transform coordinates in the _extent_ space to the _array_ space and then back after the rescaling. All tests are passing and a new unit test was added to explicitly test `set_extent`. Please let me know if other corner cases should be tested.
