### PR TITLE
remove hold deprecated already in matplotlib v2

### DIFF
--- a/modest_image/modest_image.py
+++ b/modest_image/modest_image.py
@@ -210,8 +210,7 @@ def imshow(axes, X, cmap=None, norm=None, aspect=None,
 
     Unlike matplotlib version, must explicitly specify axes
     """
-    if not axes._hold:
-        axes.cla()
+    
     if norm is not None:
         assert(isinstance(norm, mcolors.Normalize))
     if aspect is None:


### PR DESCRIPTION
"The API Changes document says: Setting or unsetting hold (deprecated in version 2.0) has now been completely removed. Matplotlib now always behaves as if hold=True. To clear an axes you can manually use cla(), or to clear an entire figure use clf()."

https://stackoverflow.com/a/63126102/2236185